### PR TITLE
Iterating over qvalues_table not annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ qvalues_table = qvalues.df
 vis_table = outliers.frac_table
 
 # Make heatmaps for significant genes
-for col in annotations.columns:
+for col in qvalues_table.columns:
     axs = blacksheep.plot_heatmap(annotations, qvalues_table, col, vis_table, savefig=True)
 
 # Normalize values


### PR DESCRIPTION
Upon downloading the package and trying to use it, I realized I was getting a `KeyError` on the line 

```
axs = blacksheep.plot_heatmap(annotations, qvalues_table, col, vis_table, savefig=True)
```

Through some digging via `pdb` and `traceback`, I realized the column names that were passed into each `plot_heatmap()` call were meant to iterate over the `qvalues_table` in the `_get_genes()` function within `visualize.py`. I understand this is an extremely small change so it's a bit annoying to have this wordy PR. However, even though I know enough to use tools like `traceback` and `pdb`,  a lot of biologists interested in the package may not know how to use such tools and might be discouraged from using the package if the `README` instructions don't work. Thus, I feel like this change merits a PR.

Thank you,
Darvesh Gorhe